### PR TITLE
Update picture source markup and make sizes attribute configurable from shortcode.

### DIFF
--- a/packages/images/utils/helpers.js
+++ b/packages/images/utils/helpers.js
@@ -25,28 +25,31 @@ function getSrcsets(maxWidth, fileSizes) {
   };
 }
 
-function getSources(sizes, srcsets) {
+function getSources(sizes, srcsets, srcSizes) {
   const sources = {
     webp: [],
     jpeg: [],
     png: [],
   };
 
-  sizes.forEach((size, i, arr) => {
-    Object.keys(srcsets).forEach((type) => {
-      if (!srcsets[type][size]) return;
-      let source = `<source `;
-      if (type === 'webp') source += `type="image/webp" `;
-      if (type === 'png') source += `type="image/png" `;
-      source += `data-srcset="${srcsets[type][size]}" `;
+  Object.entries(srcsets).forEach((srcset) => {
+    let type = srcset[0];
+    let items = srcset[1];
 
-      if (i + 1 < arr.length) {
-        source += `media="(min-width: ${size}px)" `;
-      }
-      source += `/>`;
+    if(Object.keys(items).length === 0) return; 
 
-      sources[type].push(source);
+    let source = `<source `;
+    if (type === 'webp') source += `type="image/webp" `;
+    if (type === 'png') source += `type="image/png" `;
+    source += `data-srcset="`;
+    Object.entries(items).forEach((item) => {
+      source += `${item[1]} ${item[0]}w, `; // ☝ image src with width w descriptor
     });
+    source = source.replace(/,\s*$/, "");
+    source += `" sizes="${srcSizes ? srcSizes : '100vw'}" `; // ☝ sizes attribute must be set if w descriptors are used
+    source += `>`;
+
+    sources[type] = [source];
   });
 
   return sources;

--- a/packages/images/utils/imageStore.js
+++ b/packages/images/utils/imageStore.js
@@ -20,7 +20,7 @@ const imageStore = (manifest, plugin) => {
         //todo title
 
         const { sizes, srcsets } = getSrcsets(maxWidth, file.sizes);
-        const sources = getSources(sizes, srcsets);
+        const sources = getSources(sizes, srcsets, opts.sizes);
 
         let picture = `<picture class="${classStr ? ` ${classStr}` : ''}">`;
 


### PR DESCRIPTION
In general images plugin works quite nicely for setting up responsive sizes for the same image. 
'Art direction' would be too complicated to handle for such a general tool.
 
Have some proposals though. Current picture markup looks like this

```html
<picture>
	<source type="image/webp" data-srcset="/images/img-ejs-1000.webp" media="(min-width: 1000px)">
	<source type="image/webp" data-srcset="/images/img-ejs-500.webp">
	<source data-srcset="/images/img-ejs-1000.jpeg media="(min-width: 1000px)">
	<source data-srcset="/images/img-ejs-500.jpeg">
	<img ...>
</picture>
```

🔗[respimagelint](https://ausi.github.io/respimagelint/) complains about source elements:

> Images in different <source> elements shouldn’t be the same
> The <source> element should only be used for art direction and format-based selection. For providing multiple resolutions of the same image use the srcset attribute instead.

So, with w descriptors and sizes attribute it should look like this instead

```html
<picture>
	<source type="image/webp" data-srcset="/images/img-ejs-500.jpeg 500w, /images/img-ejs-1000.webp 1000w" sizes="100vw">
	<source data-srcset="/images/img-ejs-500.jpeg 500w, /images/img-ejs-1000.jpeg 1000w" sizes="100vw" >
	<img ...>
</picture>
```

According to https://css-tricks.com/a-guide-to-the-responsive-images-syntax-in-html/#using-srcset x descriptors (1x 2x etc) only account for a small percentage of responsive images usage while using srcset / w + sizes accounts for around 85% of responsive images usage on the web.

As sizes attribute is too layout specific, it could have default value "100vw" and be configurable from shortcode as

> {{picture src='/images/img.jpg' alt="img" sizes="(min-width: 1000px) 33vw, 96vw" /}}
> {{picture src='/images/img.jpg' alt="img" sizes="(max-width: 500px) calc(100vw - 2rem), (max-width: 700px) calc(100vw - 6rem), calc(100vw - 9rem - 200px)" /}}

As I understand, exact sizes are almost impossible to set by hand as each browser does its own thing:
> So, given the same viewport size and screen density, Chrome, Safari, Firefox, and Edge may very well each pick a different resource out of a given srcset.

Also 🔗[respimagelint](https://ausi.github.io/respimagelint/) tool gives sizes suggestions that can be copied to shortcode from there.

## Used resources
* https://css-tricks.com/a-guide-to-the-responsive-images-syntax-in-html/
* https://observablehq.com/@eeeps/w-descriptors-and-sizes-under-the-hood