### PR TITLE
Escape ampersands in permalinks, replace with &amp;

### DIFF
--- a/packages/sitemap/index.js
+++ b/packages/sitemap/index.js
@@ -136,7 +136,7 @@ const plugin = {
                 );
                 if (exclude) return;
 
-                xml += `<url><loc>${plugin.config.origin}${permalink}</loc><lastmod>${formatDate(
+                xml += `<url><loc>${plugin.config.origin}${permalink.replace(/&/g, '&amp;')}</loc><lastmod>${formatDate(
                   request.lastUpdate,
                 )}</lastmod><changefreq>${request.details.changefreq}</changefreq><priority>${
                   request.details.priority


### PR DESCRIPTION
XML sitemaps with bare ampersands are invalid, e.g. `<loc>http://example.com/?key=value&param=other-value</loc>`.

To make sure none sneak through, escape them as `&amp;`, for example `<loc>http://example.com/?key=value&amp;param=other-value</loc>`