### PR TITLE
Use remark plugin strategy for slug

### DIFF
--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -33,16 +33,8 @@ const plugin = {
         ],
       ];
     }
-    if (plugin.config.slugFormatter) {
-      plugin.config.remarkPlugins.push(
-        function () {
-          return transformer
-
-          function transformer(tree, file) {
-            plugin.config.slugFormatter(tree, file);
-          }
-        }
-      );
+    if (plugin.config.slugTransformer) {
+      plugin.config.remarkPlugins.push(plugin.config.slugTransformer)
     }
 
     plugin.markdownParser = prepareMarkdownParser(plugin.config.remarkPlugins);

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -61,17 +61,8 @@ const plugin = {
 
           plugin.markdownParser.process(md);
           const { data, contents: html, data: { frontmatter } } = md;
-          let slug;
+          const slug = (frontmatter && frontmatter.slug) ? frontmatter.slug : file.stem.replace(/ /gim, '-');
 
-
-          if (frontmatter && frontmatter.slug) {
-            slug = frontmatter.slug;
-          } else {
-            slug = file.replace('.md', '').split('/').pop();
-            if (slug.includes(' ')) {
-              slug = slug.replace(/ /gim, '-');
-            }
-          }
           plugin.markdown[route].push({
             slug,
             frontmatter,

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -33,7 +33,7 @@ const plugin = {
         ],
       ];
     }
-    if (plugin.config.additionalRemarkPlugins) {
+    if (Array.isArray(plugin.config.additionalRemarkPlugins)) {
       plugin.config.additionalRemarkPlugins.forEach((remarkPlugin) => {
         plugin.config.remarkPlugins.push(remarkPlugin);
       });
@@ -63,7 +63,7 @@ const plugin = {
 
           plugin.markdownParser.process(md);
           const { data, contents: html, data: { frontmatter } } = md;
-          const slug = (frontmatter && frontmatter.slug) ? frontmatter.slug : file.stem.replace(/ /gim, '-');
+          const slug = (frontmatter && frontmatter.slug) ? frontmatter.slug : md.stem.replace(/ /gim, '-');
 
           plugin.markdown[route].push({
             slug,

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -33,8 +33,10 @@ const plugin = {
         ],
       ];
     }
-    if (plugin.config.slugTransformer) {
-      plugin.config.remarkPlugins.push(plugin.config.slugTransformer)
+    if (plugin.config.additionalRemarkPlugins) {
+      plugin.config.additionalRemarkPlugins.forEach((remarkPlugin) => {
+        plugin.config.remarkPlugins.push(remarkPlugin);
+      });
     }
 
     plugin.markdownParser = prepareMarkdownParser(plugin.config.remarkPlugins);

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -32,6 +32,7 @@
     "remark-frontmatter": "^3.0.0",
     "remark-html": "^13.0.1",
     "shiki": "^0.2.6",
+    "to-vfile": "^6.1.0",
     "unist-util-visit": "^2.0.3",
     "yaml": "^1.10.0"
   }


### PR DESCRIPTION
This is a bit cleaner but not sure if I like the transformer function setup in the markdown plugin. Perhaps would be better to be passed in from the plugin.config.remark-frontmatter-slug option? I'll replace my PR on the template repo to show how this is used.