### PR TITLE
Sitemap cleanup

### DIFF
--- a/packages/sitemap/index.js
+++ b/packages/sitemap/index.js
@@ -103,11 +103,11 @@ const plugin = {
                   // must be YYYY-MM-DD;
                   req.lastUpdate = new Date(Date.parse(plugin.config.lastUpdate[req.route]));
                 } else {
-                  console.log('Using default fallback', req);
+                  // console.log('Using default fallback', req);
                   req.lastUpdate = defaultSitemapDate;
                 }
               } else {
-                console.log('Using default fallback', req);
+                // console.log('Using default fallback', req);
                 req.lastUpdate = defaultSitemapDate;
               }
 


### PR DESCRIPTION
Currently sitemap plugin generates redundant sitemap-${route}.xml files (with empty urlset)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
</urlset>
```

 for routes which permalinks are excluded in plugin configuration and also includes these in sitemap index file. 

This PR cleans up the output.