### PR TITLE
Separate rehypeshiki config from remark plugins

### DIFF
--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -27,11 +27,18 @@ const plugin = {
         frontmatter,
         [extractFrontmatter, { name: 'frontmatter', yaml: yaml }],
         remarkHtml,
-        plugin.config.useSyntaxHighlighting && [
-          require('./rehype-shiki'),
-          typeof plugin.config.useSyntaxHighlighting === 'boolean' ? {} : plugin.config.useSyntaxHighlighting, // its an options object
-        ],
       ];
+    }
+
+    if (plugin.config.useSyntaxHighlighting) {
+      const rehypeShiki = require('./rehype-shiki');
+      let rehypeShikiConfig = {};
+      if (typeof plugin.config.useSyntaxHighlighting !== 'boolean') {
+        rehypeShikiConfig = plugin.config.useSyntaxHighlighting;
+      }
+      plugin.config.remarkPlugins.push(
+        [rehypeShiki, rehypeShikiConfig]
+      );
     }
 
     plugin.markdownParser = prepareMarkdownParser(plugin.config.remarkPlugins);


### PR DESCRIPTION
Hi @nickreese  - got another PR for you. Please take a look, thanks. This is so that `useSyntaxHighlighting` config option works even if markdown plugins are overridden - the two options should not conflict.