### PR TITLE
Browser reload failing when server is not yet up

### DIFF
--- a/packages/browser-reload/index.js
+++ b/packages/browser-reload/index.js
@@ -51,8 +51,12 @@ const plugin = {
           }
 
           async function checkServer(tryCount = 0){
-            var up = await fetch('${plugin.origin}:${plugin.serverPort}');
-            if(up.ok) return true;
+            try {
+              var up = await fetch('${plugin.origin}:${plugin.serverPort}');
+              if(up.ok) return true;
+            } catch(e) {
+              // do nothing
+            }
             if(tryCount > ${plugin.config.retryCount}){
               return false;
             }


### PR DESCRIPTION
This PR adds a try/catch to around `fetch` in `checkServer` to prevent an unhandled exception to stop the checking loop.

![image](https://user-images.githubusercontent.com/2802675/114839000-9054bf00-9dd5-11eb-8822-94b8d5464c67.png)
