### PR TITLE
Allow spaces in image plugin alt tags

### DIFF
--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -59,7 +59,7 @@ const plugin = {
 
           // replace md images if image plugin is being used
           if (plugin.settings.plugins['@elderjs/plugin-images'] && plugin.config.useElderJsPluginImages) {
-            const MDImgRegex = /!\[([A-Za-z-_\d]*)\]\(([^)]*)\)/gm;
+            const MDImgRegex = /!\[([A-Za-z-_ \d]*)\]\(([^)]*)\)/gm;
             let match;
             while ((match = MDImgRegex.exec(md)) !== null) {
               const [fullMatch, alt, src] = match;


### PR DESCRIPTION
When auto-replacing images with the `picture` shortcode, the Mardown parser regex currently doesn't catch instances with spaces in the alt tag.