### PR TITLE
Additional documentation for `helpers.markdownParser`

### DIFF
--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -70,7 +70,10 @@ In addition to parsing the markdown in the given routes, this plugin makes avail
 
 This means you can use the same markdown parser to parse markdown from other sources if needed.
 
-For full documentation please review [remark's docs](https://github.com/remarkjs/remark). That said, the default plugin config can be used to parse markdown like so: `helpers.markdownParser.processSync(mdText)`
+For full documentation please review [remark's docs](https://github.com/remarkjs/remark). That said, the default plugin config can be used to parse markdown like so:
+* `helpers.markdownParser.processSync(mdText)` if you are not using syntax highlighting
+* `helpers.markdownParser.process(mdText)` if you are using syntax highlighting. **Note that because this is an async function, it will not run inside of a non-hydrated Svelte file. To get around this, you'll want to execute the function in the `data` portion of your `route.js` file.
+
 
 ## Remark Plugins:
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -71,8 +71,8 @@ In addition to parsing the markdown in the given routes, this plugin makes avail
 This means you can use the same markdown parser to parse markdown from other sources if needed.
 
 For full documentation please review [remark's docs](https://github.com/remarkjs/remark). That said, the default plugin config can be used to parse markdown like so:
-* `helpers.markdownParser.processSync(mdText)` if you are not using syntax highlighting
-* `helpers.markdownParser.process(mdText)` if you are using syntax highlighting. **Note that because this is an async function, it will not run inside of a non-hydrated Svelte file. To get around this, you'll want to execute the function in the `data` portion of your `route.js` file.
+* `helpers.markdownParser.processSync(mdText)` if you are not using syntax highlighting.
+* `helpers.markdownParser.process(mdText)` if you are using syntax highlighting. **Note that because this is an async function, it will not run inside of a non-hydrated Svelte file. To get around this, you'll want to execute the function in the `data` portion of your `route.js` file.**
 
 
 ## Remark Plugins:


### PR DESCRIPTION
The problem in #45 still exists when trying to use the `markdownParser` helper inside of a Svelte template, because it's async. The best workaround would seem to be to use the helper in `route.js` instead. I've updated the README to explain that.