### PR TITLE
IDs in Base64 Image Placeholders

### DIFF
--- a/packages/images/package-lock.json
+++ b/packages/images/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elderjs/plugin-images",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1058,6 +1058,11 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -38,6 +38,7 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "mini-svg-data-uri": "^1.2.3",
+    "nanoid": "^3.1.30",
     "potrace": "^2.1.8",
     "sharp": "^0.26.0",
     "svgo": "^1.3.2",

--- a/packages/images/workers/placeholder.js
+++ b/packages/images/workers/placeholder.js
@@ -1,4 +1,5 @@
 const sharp = require('sharp');
+const { nanoid } = require('nanoid')
 
 module.exports = async ({ rel, src: uncheckedSrc, options, debug }) => {
   try {
@@ -10,9 +11,13 @@ module.exports = async ({ rel, src: uncheckedSrc, options, debug }) => {
 
     const place = await sharp(src).resize(options.resize).jpeg(options.jpeg).toBuffer({ resolveWithObject: false });
 
-    if (debug) console.log({ rel, placeholder: `data:image/jpeg;base64,${place.toString('base64')}`, error: null });
+    //Lighthouse makes it difficutl to tell which placeholders belong to which images, so this helps us know which one it belongs to
+    //We Stick it in the base64 image encoded URL in a place where it does not interfere with the image.
+    const id_string = `id:${nanoid()};`;
 
-    return { rel, placeholder: `data:image/jpeg;base64,${place.toString('base64')}`, error: null };
+    if (debug) console.log({ rel, placeholder: `data:image/jpeg;${id_string}base64,${place.toString('base64')}`, error: null });
+
+    return { rel, placeholder: `data:image/jpeg;${id_string}base64,${place.toString('base64')}`, error: null };
   } catch (e) {
     return { error: e };
   }

--- a/packages/images/workers/placeholder.js
+++ b/packages/images/workers/placeholder.js
@@ -9,11 +9,11 @@ module.exports = async ({ rel, src: uncheckedSrc, options, debug }) => {
       src = Buffer.from(uncheckedSrc);
     }
 
-    const place = await sharp(src).resize(options.resize).jpeg(options.jpeg).toBuffer({ resolveWithObject: false });
-
     //Lighthouse makes it difficutl to tell which placeholders belong to which images, so this helps us know which one it belongs to
     //We Stick it in the base64 image encoded URL in a place where it does not interfere with the image.
     const id_string = `id:${nanoid()};`;
+
+    const place = await sharp(src).resize(options.resize).jpeg(options.jpeg).toBuffer({ resolveWithObject: false });
 
     if (debug) console.log({ rel, placeholder: `data:image/jpeg;${id_string}base64,${place.toString('base64')}`, error: null });
 

--- a/packages/images/workers/placeholder.js
+++ b/packages/images/workers/placeholder.js
@@ -1,5 +1,5 @@
 const sharp = require('sharp');
-const { nanoid } = require('nanoid')
+const { nanoid } = require('nanoid');
 
 module.exports = async ({ rel, src: uncheckedSrc, options, debug }) => {
   try {
@@ -10,7 +10,7 @@ module.exports = async ({ rel, src: uncheckedSrc, options, debug }) => {
     }
 
     //Lighthouse makes it difficutl to tell which placeholders belong to which images, so this helps us know which one it belongs to
-    //We Stick it in the base64 image encoded URL in a place where it does not interfere with the image.
+    //much of the time, the id will actually be truncated in the Lighthouse report, but the important part is that you have enough to identify the image
     const id_string = `id:${nanoid()};`;
 
     const place = await sharp(src).resize(options.resize).jpeg(options.jpeg).toBuffer({ resolveWithObject: false });


### PR DESCRIPTION
Hey,

So this is a pull request I'm not sure if you'll want to merge or not.  I'm pretty sure it doesn't break anything, but it adds behavior which some people may not need, but a few may find very useful.

One thing that is very important to modern SEO is getting good Lighthouse scores.  This pull request deals with a specific Lighthouse notification you sometimes get - 'Displays images with incorrect aspect ratio' under 'User Experience' under 'Best Practices'.

The main issue is, when you generate placeholder images, sometimes Lighthouse doesn't like the placeholder size.  So it'll pop up with this message.  However, on sites with tons of pictures on a page (think > 5), Lighthouse is not great at letting you know which picture has the issue.  So you have to guess

This pull request adds a short 21 character ID to the base64 placeholder URL in a way that it doesn't interfere with the image.  Sometimes it'll get truncated in the report, but it makes finding out which image had the issue very very easy (literally search the DOM in Chrome or take a look at your ejs-image-manifest.json).

If you prefer a shorter ID, nanoid (the library used here) supports that very easily, and even has a tool for determining how often collisions are (we could definitely get a way with a shorter id in this case, however, I figured I'd just stick with the default).

Let me know what you think.  If you want me to put a flat in the config for this, that'd be cool too, however, I'll want to put a cache-busting mechanism in first so that way it removes the id when people turn it off and adds it back when people turn it on.  I'm working on something to help this plugin handle cache-busting and multi-level image directories a little better currently, so I'd probably tackle it after that.

Let me know what you think and I hope your having an awesome day.

