### PR TITLE
enhance: added option to shortcode to ignore `cssString`

### DIFF
--- a/packages/images/utils/imageStore.js
+++ b/packages/images/utils/imageStore.js
@@ -39,8 +39,8 @@ const imageStore = (manifest, plugin) => {
 
         picture += `</picture>`;
 
-        let pictureWithWrap = `<div class="ejs" ${
-          plugin.addStyles ? `style="padding-bottom: ${Math.round((file.height / file.width) * 10000) / 100}%;"` : ''
+        let pictureWithWrap = `<div class="${opts.ignoreCssString ? 'custom-ejs' : 'ejs'}" ${
+          plugin.addStyles && !opts.ignoreCssString ? `style="padding-bottom: ${Math.round((file.height / file.width) * 10000) / 100}%;"` : ''
         }>`;
 
         if (plugin.config.placeholder) {


### PR DESCRIPTION
Currently you can only choose to use or not use the `cssString` config prop on a global basis. This PR would allow the developer to switch the default `cssString` off on each shortcode instance. For example:

```
{@html helpers.shortcode({
	name: 'picture',
	props: {
		ignoreDefaultCss: true,
		src: '...',
		alt: '...',
		wrap: 'my-custom-class'
	},
})}
```

The way this change works is by not adding the bottom padding on the picture wrapper and setting the wrapper class to `custom-ejs` instead of `ejs` in order for the default `cssString` class definition of `ejs` not to apply.