### PR TITLE
fixed webp compression

### DIFF
--- a/packages/images/workers/resize.js
+++ b/packages/images/workers/resize.js
@@ -103,9 +103,6 @@ const resize = async ({
     } else if (fileType === 'webp') {
       image = await image.webp({
         quality,
-        reductionEffort: 6,
-        nearLossless: true,
-        smartSubsample: true,
       });
     }
 


### PR DESCRIPTION
The extra parameters in the webp compression did not work and increase the size of the image (sometimes even by 50%). By removing the parameters the plugin works perfectly and the quality is still picked from the config.