### PR TITLE
Make the slug draft prefix check consistent, and DRY

### DIFF
--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -14,6 +14,7 @@ import { PluginOptions, PluginInitPayload } from '@elderjs/elderjs';
 
 import prepareMarkdownParser from './utils/prepareMarkdownParser.js';
 import createMarkdownStore, { Ret } from './utils/markdownStore.js';
+import isDraft from './utils/isDraft.ts';
 import rehypeShiki from './utils/rehype-shiki.js';
 import tableOfContents from './utils/tableOfContents.js';
 
@@ -159,11 +160,11 @@ const plugin: PluginOptions = {
           Object.keys(internal.markdown).forEach((route) => {
             if (process.env.NODE_ENV === 'production') {
               internal.markdown[route] = internal.markdown[route].filter(
-                (md) => !md.frontmatter.draft && md.slug.indexOf('draft-') !== 0,
+                (md) => !isDraft(md),
               );
             } else {
               internal.markdown[route].forEach((md) => {
-                if (md.frontmatter.draft || md.slug.indexOf('draft-') === 0) {
+                if (isDraft(md)) {
                   md.frontmatter.title = `DRAFT: ${md.frontmatter.title || 'MISSING TITLE'}`;
                 }
               });

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -163,7 +163,7 @@ const plugin: PluginOptions = {
               );
             } else {
               internal.markdown[route].forEach((md) => {
-                if (md.frontmatter.draft || md.slug.indexOf('draft') === 0) {
+                if (md.frontmatter.draft || md.slug.indexOf('draft-') === 0) {
                   md.frontmatter.title = `DRAFT: ${md.frontmatter.title || 'MISSING TITLE'}`;
                 }
               });

--- a/packages/markdown/src/utils/isDraft.ts
+++ b/packages/markdown/src/utils/isDraft.ts
@@ -1,0 +1,3 @@
+import type { Ret } from './markdownStore.js';
+
+export default (md: Ret) => md?.frontmatter?.draft || md?.slug?.startsWith('draft-');


### PR DESCRIPTION
Checking for a prefix of "draft" could lead to false positives or inconsistent results between dev and prod.

I also took the opportunity to move the draft-checking logic to its own utility function.

No hurry on this. Made the PR against typescript branch.

